### PR TITLE
Configurable background job

### DIFF
--- a/bin/run-job
+++ b/bin/run-job
@@ -1,0 +1,20 @@
+#!/usr/bin/env php
+<?php
+
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+} else {
+    require_once __DIR__ . '/../../../autoload.php';
+}
+
+parse_str($argv[2], $config);
+
+$cls = $config['jobClass'];
+
+if (!is_a($cls, 'Jobby\BackgroundJob', true)) {
+    throw new Jobby\Exception('"jobClass" needs to be an instanceof Jobby\BackgroundJob');
+}
+
+/** @var \Jobby\BackgroundJob $job */
+$job = new $cls($argv[1], $config);
+$job->run();

--- a/src/BackgroundJob.php
+++ b/src/BackgroundJob.php
@@ -284,23 +284,3 @@ class BackgroundJob
         }
     }
 }
-
-// run this file, if executed directly
-// @see: http://stackoverflow.com/questions/2413991/php-equivalent-of-pythons-name-main
-// @codeCoverageIgnoreStart
-$trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
-if (!empty($trace)) {
-    return;
-}
-
-if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-    require_once __DIR__ . '/../vendor/autoload.php';
-} else {
-    require_once __DIR__ . '/../../../autoload.php';
-}
-
-global $argv;
-parse_str($argv[2], $config);
-$job = new BackgroundJob($argv[1], $config);
-$job->run();
-// @codeCoverageIgnoreEnd

--- a/src/Jobby.php
+++ b/src/Jobby.php
@@ -35,7 +35,7 @@ class Jobby
         $this->setConfig($this->getDefaultConfig());
         $this->setConfig($config);
 
-        $this->script = __DIR__ . DIRECTORY_SEPARATOR . 'BackgroundJob.php';
+        $this->script = realpath(__DIR__ . '/../bin/run-job');
     }
 
     /**
@@ -56,6 +56,7 @@ class Jobby
     public function getDefaultConfig()
     {
         return [
+            'jobClass'       => 'Jobby\BackgroundJob',
             'recipients'     => null,
             'mailer'         => 'sendmail',
             'maxRuntime'     => null,

--- a/tests/JobbyTest.php
+++ b/tests/JobbyTest.php
@@ -286,7 +286,7 @@ class JobbyTest extends \PHPUnit_Framework_TestCase
         $jobby->run();
         sleep(2);
         $jobby->run();
-        sleep(1);
+        sleep(2);
 
         $this->assertContains('ERROR: MaxRuntime of 1 secs exceeded!', $this->getLogContent());
     }


### PR DESCRIPTION
Moved logic for running a job to separate file. 

`BackgroundJob` class can now be overridden with _jobClass_ config option.