### PR TITLE
Closure updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php:
   - 5.4
   - 5.5
@@ -9,7 +11,6 @@ php:
 
 matrix:
   allow_failures:
-    - php: 7.0
     - php: hhvm
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -1,28 +1,13 @@
-[![Build Status](https://secure.travis-ci.org/hellogerard/jobby.png)](http://travis-ci.org/hellogerard/jobby)
+# Jobby, a PHP cron job manager #
+[![Total Downloads](https://img.shields.io/packagist/dt/hellogerard/jobby.svg)](https://packagist.org/packages/hellogerard/jobby)
+[![Latest Version](https://img.shields.io/packagist/v/hellogerard/jobby.svg)](https://packagist.org/packages/hellogerard/jobby)
+[![Build Status](https://img.shields.io/travis/hellogerard/jobby.svg)](https://travis-ci.org/hellogerard/jobby)
+[![MIT License](https://img.shields.io/packagist/l/hellogerard/jobby.svg)](https://github.com/hellogerard/jobby/blob/master/LICENSE)
 
-`Jobby` is a PHP cron job manager. Install the master jobby cron job, and it will
-manage all your offline tasks. Add jobs without modifying crontab. Jobby can
-handle logging, locking, error emails and more.
+Install the master jobby cron job, and it will manage all your offline tasks. Add jobs without modifying crontab.
+Jobby can handle logging, locking, error emails and more.
 
-## Install ##
-
-1. Install [`composer`](<http://getcomposer.org>).
-2. Add `jobby` to your `composer.json`.
-
-  `'hellogerard/jobby': 'dev-master'`
-
-3. Run `composer install`.
-4. Add the following line to your (or whomever's) crontab:
-
-  `* * * * * cd /path/to/project && php jobby.php 1>> /dev/null 2>&1`
-
-After `jobby` installs, you can copy an example jobby file to the project root.
-
-  `% cp vendor/hellogerard/jobby/resources/jobby.php .`
-
-## Usage ##
-
-### Features ###
+## Features ##
 
 - Maintain one master crontab job.
 - Jobs run via PHP, so you can run them under any programmatic conditions.
@@ -33,67 +18,35 @@ After `jobby` installs, you can copy an example jobby file to the project root.
 - Run only on certain hostnames (handy in webfarms).
 - Theoretical Windows support (but not ever tested)
 
-### Currently Supported Options ###
-
-Global options can be given to the `Jobby` object constructor. These will be
-used as a default for all subsequent jobs. Individual jobs can override a
-particular option when the job is `added`.
-
-<pre>
-Option         | Default                             | Required | Description
-===============+=====================================+==========+============
-               |                                     |          |
-recipients     | null                                | No       | Comma-separated string of email addresses
-mailer         | sendmail                            | No       | Email method: sendmail or smtp or mail
-smtpHost       | null                                | No       | SMTP host, if `mailer` is smtp
-smtpPort       | 25                                  | No       | SMTP port, if `mailer` is smtp
-smtpUsername   | null                                | No       | SMTP user, if `mailer` is smtp
-smtpPassword   | null                                | No       | SMTP password, if `mailer` is smtp
-smtpSecurity   | null                                | No       | SMTP security option (ssl|tls), if `mailer` is smtp
-smtpSender     | jobby@&lt;hostname&gt;                    | No       | The sender and from addresses used in SMTP notices
-smtpSenderName | Jobby                               | No       | The name used in the from field for SMTP messages
-runAs          | null                                | No       | Run as this user, if crontab user has `sudo` privileges
-environment    | null or `getenv('APPLICATION_ENV')` | No       | Development environment for this job
-runOnHost      | `gethostname()`                     | No       | Run jobs only on this hostname
-maxRuntime     | null                                | No       | Maximum execution time for this job (in seconds)
-output         | /dev/null                           | No       | Redirect `stdout` and `stderr` to this file
-dateFormat     | 'Y-m-d H:i:s'                       | No       | Format for dates on `jobby` log messages
-enabled        | true                                | No       | Run this job at scheduled times
-haltDir        | null                                | No       | A job will not run if this directory contains a file bearing the job's name
-debug          | false                               | No       | Send `jobby` internal messages to 'debug.log'
-command        | none                                | Yes      | The job to run (either a shell command or anonymous PHP function)
-schedule       | none                                | Yes      | Crontab schedule format (`man -s 5 crontab`) or Datetime format
-</pre>
-
-### Example `jobby.php` File ###
+## Example ##
 
 ```php
 <?php 
 
-require(__DIR__ . '/vendor/autoload.php');
+require_once __DIR__ . '/vendor/autoload.php';
 
-$jobby = new \Jobby\Jobby();
+$jobby = new Jobby\Jobby();
 
 // Every job has a name
-$jobby->add('CommandExample', array(
-    // Commands are either shell commands or anonymous functions
-    'command' => 'ls',
+$jobby->add('CommandExample', [
+    // Run a shell commands
+    'command'  => 'ls',
 
     // Ordinary crontab schedule format is supported.
     // This schedule runs every hour.
-    // You could also insert Datetime string.
+    // You could also insert DateTime string in the format of Y-m-d H:i:s.
     'schedule' => '0 * * * *',
 
     // Stdout and stderr is sent to the specified file
-    'output' => 'logs/command.log',
+    'output'   => 'logs/command.log',
 
     // You can turn off a job by setting 'enabled' to false
-    'enabled' => true,
-));
+    'enabled'  => true,
+]);
 
-$jobby->add('ClosureExample', array(
-    // Commands can be PHP closures
-    'command' => function() {
+$jobby->add('ClosureExample', [
+    // Invoke PHP closures
+    'closure'  => function() {
         echo "I'm a function!\n";
         return true;
     },
@@ -101,19 +54,69 @@ $jobby->add('ClosureExample', array(
     // This function will run every other hour
     'schedule' => '0 */2 * * *',
 
-    'output' => 'logs/closure.log',
-    'enabled' => true,
-));
+    'output'   => 'logs/closure.log',
+]);
 
 $jobby->run();
 ```
 
-### Paid Support
+## Installation ##
 
-[![Support and Consulting Services](https://s3-us-west-2.amazonaws.com/supportedsourceassets/buttons/supportandservices1.png)](http://supportedsource.org/consulting-services-and-support/jobby)
+The recommended way to install Jobby is through [Composer](http://getcomposer.org):
+```
+$ composer require hellogerard/jobby
+```
 
-### Credits ###
+Then add the following line to your (or whomever's) crontab:
+```
+* * * * * cd /path/to/project && php jobby.php 1>> /dev/null 2>&1
+```
 
-Developed before, but since inspired by [`whenever`](<https://github.com/javan/whenever>).
+After Jobby installs, you can copy an example file to the project root.
+```
+$ cp vendor/hellogerard/jobby/resources/jobby.php .
+```
+
+## Supported Options ##
+
+Each job requires these:
+
+Key       | Type    | Description
+:-------- | :------ | :------------------------------------------------------------------------------
+schedule  | string  | Crontab schedule format (`man -s 5 crontab`) or DateTime format (`Y-m-d H:i:s`)
+command   | string  | The shell command to run (exclusive-or with `closure`)
+closure   | Closure | The anonymous PHP function to run (exclusive-or with `command`)
+
+
+The options listed below can be applied to an individual job or globally through the `Jobby` constructor. 
+Global options will be used as default values, and individual jobs can override them.
+
+Option         | Type      | Default                             | Description
+:------------- | :-------- | :---------------------------------- | :-------------------------------------------------------- 
+runAs          | string    | null                                | Run as this user, if crontab user has `sudo` privileges
+debug          | boolean   | false                               | Send `jobby` internal messages to 'debug.log'
+_**Filtering**_|           |                                     | _**Options to determine whether the job should run or not**_ 
+environment    | string    | null or `getenv('APPLICATION_ENV')` | Development environment for this job
+runOnHost      | string    | `gethostname()`                     | Run jobs only on this hostname
+maxRuntime     | integer   | null                                | Maximum execution time for this job (in seconds)
+enabled        | boolean   | true                                | Run this job at scheduled times
+haltDir        | string    | null                                | A job will not run if this directory contains a file bearing the job's name 
+_**Logging**_  |           |                                     | _**Options for logging**_
+output         | string    | /dev/null                           | Redirect `stdout` and `stderr` to this file
+dateFormat     | string    | Y-m-d H:i:s                         | Format for dates on `jobby` log messages
+_**Mailing**_  |           |                                     | _**Options for emailing errors**_
+recipients     | string    | null                                | Comma-separated string of email addresses
+mailer         | string    | sendmail                            | Email method: _sendmail_ or _smtp_ or _mail_
+smtpHost       | string    | null                                | SMTP host, if `mailer` is smtp
+smtpPort       | integer   | 25                                  | SMTP port, if `mailer` is smtp
+smtpUsername   | string    | null                                | SMTP user, if `mailer` is smtp
+smtpPassword   | string    | null                                | SMTP password, if `mailer` is smtp
+smtpSecurity   | string    | null                                | SMTP security option: _ssl_ or _tls_, if `mailer` is smtp
+smtpSender     | string    | jobby@&lt;hostname&gt;              | The sender and from addresses used in SMTP notices
+smtpSenderName | string    | Jobby                               | The name used in the from field for SMTP messages
+
+## Credits ##
+
+Developed before, but since inspired by [whenever](<https://github.com/javan/whenever>).
 
 [Support this project](https://cash.me/$hellogerard)

--- a/bin/run-job
+++ b/bin/run-job
@@ -1,0 +1,20 @@
+#!/usr/bin/env php
+<?php
+
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    require_once __DIR__ . '/../vendor/autoload.php';
+} else {
+    require_once __DIR__ . '/../../../autoload.php';
+}
+
+parse_str($argv[2], $config);
+
+$cls = $config['jobClass'];
+
+if (!is_a($cls, 'Jobby\BackgroundJob', true)) {
+    throw new Jobby\Exception('"jobClass" needs to be an instanceof Jobby\BackgroundJob');
+}
+
+/** @var \Jobby\BackgroundJob $job */
+$job = new $cls($argv[1], $config);
+$job->run();

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=5.4",
     "mtdowling/cron-expression": "^1.0",
     "swiftmailer/swiftmailer": "^5.4",
-    "jeremeamia/superclosure": "^2.1",
+    "jeremeamia/superclosure": "^2.2",
     "symfony/process": "^2.7"
   },
   "require-dev": {

--- a/src/BackgroundJob.php
+++ b/src/BackgroundJob.php
@@ -284,23 +284,3 @@ class BackgroundJob
         }
     }
 }
-
-// run this file, if executed directly
-// @see: http://stackoverflow.com/questions/2413991/php-equivalent-of-pythons-name-main
-// @codeCoverageIgnoreStart
-$trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
-if (!empty($trace)) {
-    return;
-}
-
-if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-    require_once __DIR__ . '/../vendor/autoload.php';
-} else {
-    require_once __DIR__ . '/../../../autoload.php';
-}
-
-global $argv;
-parse_str($argv[2], $config);
-$job = new BackgroundJob($argv[1], $config);
-$job->run();
-// @codeCoverageIgnoreEnd

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -1,8 +1,6 @@
 <?php
 namespace Jobby;
 
-use SuperClosure\SerializableClosure;
-
 class Helper
 {
     /**
@@ -223,18 +221,6 @@ EOF;
         } else {
             return self::UNIX;
         }
-    }
-
-    /**
-     * @param \Closure $fn
-     *
-     * @return string
-     */
-    public function closureToString(\Closure $fn)
-    {
-        $code = new SerializableClosure($fn);
-
-        return serialize($code);
     }
 
     /**

--- a/src/Jobby.php
+++ b/src/Jobby.php
@@ -35,7 +35,7 @@ class Jobby
         $this->setConfig($this->getDefaultConfig());
         $this->setConfig($config);
 
-        $this->script = __DIR__ . DIRECTORY_SEPARATOR . 'BackgroundJob.php';
+        $this->script = realpath(__DIR__ . '/../bin/run-job');
     }
 
     /**
@@ -56,6 +56,7 @@ class Jobby
     public function getDefaultConfig()
     {
         return [
+            'jobClass'       => 'Jobby\BackgroundJob',
             'recipients'     => null,
             'mailer'         => 'sendmail',
             'maxRuntime'     => null,

--- a/src/SerializerTrait.php
+++ b/src/SerializerTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Jobby;
+
+use SuperClosure\Serializer;
+
+trait SerializerTrait
+{
+    /**
+     * @var Serializer
+     */
+    protected $serializer;
+
+    /**
+     * @return Serializer
+     */
+    protected function getSerializer()
+    {
+        if ($this->serializer === null) {
+            $this->serializer = new Serializer();
+        }
+
+        return $this->serializer;
+    }
+}

--- a/tests/HelperTest.php
+++ b/tests/HelperTest.php
@@ -71,26 +71,6 @@ class HelperTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers ::closureToString
-     */
-    public function testClosureToString()
-    {
-        $closure = function ($args) {
-            return $args . 'bar';
-        };
-
-        $serialized = $this->helper->closureToString($closure);
-
-        /** @var \Closure $actual */
-        $actual = @unserialize($serialized);
-        $actual = $actual('foo');
-
-        $expected = $closure('foo');
-
-        $this->assertEquals($expected, $actual);
-    }
-
-    /**
      * @covers ::getPlatform
      */
     public function testGetPlatform()

--- a/tests/JobbyTest.php
+++ b/tests/JobbyTest.php
@@ -286,7 +286,7 @@ class JobbyTest extends \PHPUnit_Framework_TestCase
         $jobby->run();
         sleep(2);
         $jobby->run();
-        sleep(1);
+        sleep(2);
 
         $this->assertContains('ERROR: MaxRuntime of 1 secs exceeded!', $this->getLogContent());
     }

--- a/tests/SerializerTraitTest.php
+++ b/tests/SerializerTraitTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Jobby\Tests;
+
+class SerializerTraitTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetSerializer()
+    {
+        $mock = $this->getObjectForTrait('Jobby\SerializerTrait');
+        $method = new \ReflectionMethod($mock, 'getSerializer');
+        $method->setAccessible(true);
+
+        $serializer = $method->invoke($mock);
+        $this->assertInstanceOf('\SuperClosure\Serializer', $serializer);
+
+        $serializer2 = $method->invoke($mock);
+        $this->assertSame($serializer, $serializer2);
+    }
+}


### PR DESCRIPTION
- Serializing with `SuperClosure\Serializer`. If a `SerializableClosure` into Jobby, the normal closure is just retrieved from it and it is serialized with the default serializer. Until code is written to be able to pass in a Serializer into the BackgroundJob there's no reason to use anything but the default. 
- Closures should be set to `closure` key instead of `command` (BC is maintained of course). This prevents us from having to try and figure out if string is a serialized closure or a command to run.
- Updated README for these changes and in general. See [here](https://github.com/CarsonF/jobby/blob/feature/closure-updates/README.md)

Depends on #44 