### PR TITLE
Update BackgroundJob.php

### DIFF
--- a/src/BackgroundJob.php
+++ b/src/BackgroundJob.php
@@ -233,7 +233,11 @@ class BackgroundJob
         $command = $this->getSerializer()->unserialize($this->config['closure']);
 
         ob_start();
-        $retval = $command();
+        try {
+            $retval = $command();
+        } catch (\Throwable $e) {
+            echo "Error! " . $e->getMessage() . "\n";
+        }
         $content = ob_get_contents();
         if ($logfile = $this->getLogfile()) {
             file_put_contents($this->getLogfile(), $content, FILE_APPEND);


### PR DESCRIPTION
If an error happens during the command's execution, it will be silent. This makes sure it isn't silent, and that the output gets logged regardless.

I ran into this issue trying to make PHP-DI work with Jobby (basically wanted to autowire my job classes to use dependencies defined by the app) and noticed the output is silent when it errors out, i.e. stuff like:

```
Argument 1 passed to Standard\Cron\ExampleCronTask::helloWorld() must be an instance of Psr\Log\LoggerInterface, none given, called in /home/vagrant/Code/nofw/vendor/jeremeamia/SuperClosure/src/SerializableClosure.php(210) : eval()'d code on line 3
```

This type of message now gets logged to the error log as well, helping the debug process.