### PR TITLE
Casts cron express to string before calling CronExpression::factory()

### DIFF
--- a/src/ScheduleChecker.php
+++ b/src/ScheduleChecker.php
@@ -17,6 +17,6 @@ class ScheduleChecker
             return $dateTime->format('Y-m-d H:i') == (date('Y-m-d H:i'));
         }
 
-        return CronExpression::factory($schedule)->isDue();
+        return CronExpression::factory((string)$schedule)->isDue();
     }
 }


### PR DESCRIPTION
This allows the use of objects implementing __toString() to be used as the schedule key in Jobby config (e.g. objects returned by garethellis/crontab-schedule-generator):

```php
use function \Garethellis\CrontabScheduleGenerator\daily;

$jobby->add("job", [
  "schedule" => daily(),
  "command" => "ls"
]);
```

In this example, the `daily()` function is a factory method for the `Daily` object. This object implements `__toString()` and can be echoed out as "0 0 * * *". However, without this PR, `CronExpression::factory()` emits a warning because PHP does not allow the use of string-like objects as array offsets.

This PR therefore casts the schedule key to string before invoking `CronExpression::factory()` to get around this limitation.

