### PR TITLE
Helper "get" methods for Jobby & BackgroundJob

### DIFF
--- a/src/BackgroundJob.php
+++ b/src/BackgroundJob.php
@@ -108,6 +108,14 @@ class BackgroundJob
     }
 
     /**
+     * @return array
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
+
+    /**
      * @param string $lockFile
      *
      * @throws Exception

--- a/src/Jobby.php
+++ b/src/Jobby.php
@@ -98,6 +98,14 @@ class Jobby
     }
 
     /**
+     * @return array
+     */
+    public function getJobs()
+    {
+        return $this->jobs;
+    }
+
+    /**
      * Add a job.
      *
      * @param string $job

--- a/tests/BackgroundJobTest.php
+++ b/tests/BackgroundJobTest.php
@@ -72,6 +72,15 @@ class BackgroundJobTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers ::getConfig
+     */
+    public function testGetConfig()
+    {
+        $job = new BackgroundJob('test job',[]);
+        $this->assertInternalType('array',$job->getConfig());
+    }
+
+    /**
      * @dataProvider runProvider
      *
      * @covers ::run

--- a/tests/JobbyTest.php
+++ b/tests/JobbyTest.php
@@ -247,6 +247,33 @@ class JobbyTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers ::getJobs
+     */
+    public function testGetJobs()
+    {
+        $jobby = new Jobby();
+        $this->assertCount(0,$jobby->getJobs());
+        
+        $jobby->add(
+            'test job1',
+            [
+                'command' => 'test',
+                'schedule' => '* * * * *'
+            ]
+        );
+
+        $jobby->add(
+            'test job2',
+            [
+                'command' => 'test',
+                'schedule' => '* * * * *'
+            ]
+        );
+
+        $this->assertCount(2,$jobby->getJobs());
+    }
+
+    /**
      * @covers ::add
      * @expectedException \Jobby\Exception
      */


### PR DESCRIPTION
Added getConfig() to BackgroundJob
Added getJobs() to Jobby

It would be useful in a current project to be able to view all the configured cron jobs and to also inspect the config of each job. Added 2 additional methods to facilitate this.