### PR TITLE
fix swiftmailer 6 code, as newInstance is no longer a function

### DIFF
--- a/src/Helper.php
+++ b/src/Helper.php
@@ -76,7 +76,7 @@ EOF;
         $swiftVersion = (int) explode('.', \Swift::VERSION)[0];
 
         if ($config['mailer'] === 'smtp') {
-            $transport = \Swift_SmtpTransport::newInstance(
+            $transport = new \Swift_SmtpTransport(
                 $config['smtpHost'],
                 $config['smtpPort'],
                 $config['smtpSecurity']
@@ -86,10 +86,10 @@ EOF;
         } elseif ($swiftVersion < 6 && $config['mailer'] === 'mail') {
             $transport = \Swift_MailTransport::newInstance();
         } else {
-            $transport = \Swift_SendmailTransport::newInstance();
+            $transport = new \Swift_SendmailTransport();
         }
 
-        return \Swift_Mailer::newInstance($transport);
+        return new \Swift_Mailer($transport);
     }
 
     /**


### PR DESCRIPTION
I was getting this error:

PHP Fatal error:  Uncaught Error: Call to undefined method Swift_Mailer::newInstance() in /var/www/dragoman/protected/vendor/hellogerard/jobby/src/Helper.php:92

so I fixed to just use constructor.