### PR TITLE
Fix PHP_NOTICE "$retval is undefined" in case of an exception.

### DIFF
--- a/src/BackgroundJob.php
+++ b/src/BackgroundJob.php
@@ -235,6 +235,7 @@ class BackgroundJob
             $retval = $command();
         } catch (\Throwable $e) {
             echo "Error! " . $e->getMessage() . "\n";
+            $retval = $e->getMessage();
         }
         $content = ob_get_contents();
         if ($logfile = $this->getLogfile()) {


### PR DESCRIPTION
Simple solution: set error message as return value to provide it in 
jobby's exception message too.

A better/different way might be to declare $retval before and also an exception var, to chain it as previous exception to jobby's exception if set. This would result in a clearer stack trace.