### PR TITLE
Pin the time before looping jobs and running them in order to prevent schedule slip

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,9 +166,9 @@ $jobby->add('Example', [
     // Use any callable that returns
     // a boolean stating whether
     // to run the job or not
-    'schedule' => function() {
+    'schedule' => function(DateTimeImmutable $now) {
         // Run on even minutes
-        return date('i') % 2 === 0;
+        return $now->format('i') % 2 === 0;
     },
 
 ]);

--- a/src/Jobby.php
+++ b/src/Jobby.php
@@ -3,6 +3,7 @@
 namespace Jobby;
 
 use Closure;
+use DateTimeImmutable;
 use SuperClosure\SerializableClosure;
 use Symfony\Component\Process\PhpExecutableFinder;
 
@@ -152,7 +153,7 @@ class Jobby
             throw new Exception('posix extension is required');
         }
 
-        $scheduleChecker = new ScheduleChecker();
+        $scheduleChecker = new ScheduleChecker(new DateTimeImmutable("now"));
         foreach ($this->jobs as $jobConfig) {
             list($job, $config) = $jobConfig;
             if (!$scheduleChecker->isDue($config['schedule'])) {

--- a/src/ScheduleChecker.php
+++ b/src/ScheduleChecker.php
@@ -3,9 +3,20 @@
 namespace Jobby;
 
 use Cron\CronExpression;
+use DateTimeImmutable;
 
 class ScheduleChecker
 {
+    /**
+     * @var DateTimeImmutable|null
+     */
+    private $now;
+
+    public function __construct(DateTimeImmutable $now = null)
+    {
+        $this->now = $now instanceof DateTimeImmutable ? $now : new DateTimeImmutable("now");
+    }
+
     /**
      * @param string|callable $schedule
      * @return bool
@@ -13,14 +24,14 @@ class ScheduleChecker
     public function isDue($schedule)
     {
         if (is_callable($schedule)) {
-            return call_user_func($schedule);
+            return call_user_func($schedule, $this->now);
         }
 
         $dateTime = \DateTime::createFromFormat('Y-m-d H:i:s', $schedule);
         if ($dateTime !== false) {
-            return $dateTime->format('Y-m-d H:i') == (date('Y-m-d H:i'));
+            return $dateTime->format('Y-m-d H:i') == $this->now->format('Y-m-d H:i');
         }
 
-        return CronExpression::factory((string)$schedule)->isDue();
+        return CronExpression::factory((string)$schedule)->isDue($this->now);
     }
 }

--- a/tests/JobbyTest.php
+++ b/tests/JobbyTest.php
@@ -324,9 +324,9 @@ class JobbyTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $timeStart = microtime();
+        $timeStart = microtime(true);
         $jobby->run();
-        $duration = microtime() - $timeStart;
+        $duration = microtime(true) - $timeStart;
 
         $this->assertLessThan(0.5, $duration);
     }

--- a/tests/ScheduleCheckerTest.php
+++ b/tests/ScheduleCheckerTest.php
@@ -2,6 +2,7 @@
 
 namespace Jobby\Tests;
 
+use DateTimeImmutable;
 use Jobby\ScheduleChecker;
 use PHPUnit_Framework_TestCase;
 
@@ -28,6 +29,17 @@ class ScheduleCheckerTest extends PHPUnit_Framework_TestCase
     public function test_it_can_detect_a_due_job_from_a_datetime_string()
     {
         $this->assertTrue($this->scheduleChecker->isDue(date('Y-m-d H:i:s')));
+    }
+
+    /**
+     * @return void
+     */
+    public function test_it_can_detect_if_a_job_is_due_with_a_passed_in_DateTimeImmutable()
+    {
+        $scheduleChecker = new ScheduleChecker(new DateTimeImmutable("2017-01-02 13:14:59"));
+
+        $this->assertTrue($scheduleChecker->isDue(date("2017-01-02 13:14:12")));
+        $this->assertFalse($scheduleChecker->isDue(date("2017-01-02 13:15:00")));
     }
 
     /**
@@ -77,5 +89,15 @@ class ScheduleCheckerTest extends PHPUnit_Framework_TestCase
                 return false;
             })
         );
+    }
+
+    /**
+     * @return void
+     */
+    public function test_it_can_detect_if_a_job_is_due_with_a_passed_in_DateTimeImmutable_from_a_cron_expression()
+    {
+        $scheduleChecker = new ScheduleChecker(new DateTimeImmutable("2017-01-02 18:14:59"));
+
+        $this->assertTrue($scheduleChecker->isDue("* 18 * * *"));
     }
 }


### PR DESCRIPTION
Addresses issue #100.

I have done this in such a way as there are no BC breaks. That way if someone is sub-classing Jobby or ScheduleChecker they will continue to work as before.