### PR TITLE
Right use of PDO sentence

### DIFF
--- a/resources/jobby-pdo.php
+++ b/resources/jobby-pdo.php
@@ -57,7 +57,7 @@ $insertCronJobConfiguration = $dbh->prepare("
 INSERT INTO `$dbhJobbiesTableName`
  (`name`,`command`,`schedule`,`output`)
  VALUES
- (:name,:command,:schedule,:output)
+ (?,?,?,?)
 ");
 // First demo-job - print "date" to logs/command-pdo.log.
 $insertCronJobConfiguration->execute(


### PR DESCRIPTION
When you use named parameters you must create an array with key, and the key must have the same name that was defined in the query, also called placeholder.

Currently the script sends positional parameters.