### PR TITLE
Replace cron-expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Jobby can handle logging, locking, error emails and more.
 
 - Maintain one master crontab job.
 - Jobs run via PHP, so you can run them under any programmatic conditions.
-- Use ordinary crontab schedule syntax (powered by the excellent [`cron-expression`](<https://github.com/mtdowling/cron-expression>)).
+- Use ordinary crontab schedule syntax (powered by the excellent [`cron-expression`](<https://github.com/dragonmantank/cron-expression>)).
 - Run only one copy of a job at a given time.
 - Send email whenever a job exits with an error status. 
 - Run job as another user, if crontab user has `sudo` privileges.

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
   ],
   "require": {
     "php": ">=5.6",
-    "mtdowling/cron-expression": "^1.0",
-    "swiftmailer/swiftmailer": "^5.4|^6.0",
+    "dragonmantank/cron-expression": "^3.0",
     "jeremeamia/superclosure": "^2.2",
+    "swiftmailer/swiftmailer": "^5.4|^6.0",
     "symfony/process": "^2.7|^3.0|^4.0|^5.0"
   },
   "require-dev": {
@@ -34,5 +34,8 @@
     "psr-4": {
       "Jobby\\Tests\\": "tests"
     }
+  },
+  "config": {
+    "sort-packages": true
   }
 }

--- a/tests/ScheduleCheckerTest.php
+++ b/tests/ScheduleCheckerTest.php
@@ -61,6 +61,16 @@ class ScheduleCheckerTest extends PHPUnit_Framework_TestCase
     /**
      * @return void
      */
+    public function test_it_can_detect_a_due_job_from_a_non_trivial_cron_expression()
+    {
+        $scheduleChecker = new ScheduleChecker(new DateTimeImmutable("2017-04-01 00:00:00"));
+
+        $this->assertTrue($scheduleChecker->isDue("0 0 1 */3 *"));
+    }
+
+    /**
+     * @return void
+     */
     public function test_it_can_detect_a_non_due_job_from_a_cron_expression()
     {
         $hour = date("H", strtotime('+1 hour'));


### PR DESCRIPTION
This may introduce breaking changes as "dragonmantank/cron-expression" fixes many issues with how the cron expression is processed(according to the [README](https://github.com/dragonmantank/cron-expression)). For me, there are no issues, but I'm not doing anything fancy with it.

I have also added a test that fails in the current version and passes in this version.

All current tests are green.